### PR TITLE
ignore add com.puppycrawl.tools:checkstyle

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -35,6 +35,8 @@ licensing:
       # runs under BSD License or GNU General Public License (GPL) Version 2
       # it@m is using BSD License (see also https://github.com/digitalbazaar/forge/blob/main/LICENSE)
       - node-forge
+      # false positive: wird während des Build benutzt, ist aber nich Teil der Software
+      - com.puppycrawl.tools:checkstyle
 
 secretscanning:
   level: all


### PR DESCRIPTION
com.puppycrawl.tools:checkstyle is detected (sometimes ...) as library with LGPL-2.1. I do not agree with the assessment as error for the following reasons:

- only use during creation of software via `maven-checkstyle-plugin`
  - `Activities other than copying, distribution and modification are not
covered by this License; they are outside its scope`
  - `The act of
running a program using the Library is not restricted, and output from
such a program is covered only if its contents constitute a work based
on the Library`
- no distribution
- we do not develop checkstyle

---

I am not sure that I have chosen the right syntax:  
![grafik](https://github.com/it-at-m/policy-as-code/assets/13592751/d01b55af-7748-4070-8acf-4fc97461c801)
